### PR TITLE
fix minor typos in readme and tutorial 1

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ section 1.3. Note that you need to copy over cudnn files to your local cuda. For
 
 - `cp cudnn-*-archive/include/cudnn*.h <path_to_your_cuda>/include`
 - `cp -P cudnn-*-archive/lib/libcudnn* <path_to_your_cuda>/lib64`
-- `chmod a+r /usr/local/cuda/include/cudnn*.h <path_to_your_cuda>/libcudnn*`
+- `chmod a+r <path_to_your_cuda>/include/cudnn*.h <path_to_your_cuda>/lib64/libcudnn*`
 
 2. Install Jax by running `pip install --upgrade "jax[cuda]" -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html`, as shown [here](https://github.com/google/jax#installation).
 3. Run `pip install dm-haiku msgpack optax`

--- a/tutorials/1_run_featurizers.py
+++ b/tutorials/1_run_featurizers.py
@@ -196,7 +196,7 @@ if __name__ == "__main__":
     elif args.labeling_function == "mortality":
         labeler = InpatientMortalityLabeler(ontology)
     elif args.labeling_function == "long_los":
-        labeler = InpatientReadmissionLabeler(ontology)
+        labeler = InpatientLongAdmissionLabeler(ontology)
     elif args.labeling_function == "readmission":
         labeler = InpatientReadmissionLabeler(ontology)
     elif args.labeling_function == "lupus":


### PR DESCRIPTION
- minor typo in cudnn installation guide in README 
- minor typo in tutorials/1_run_featurizer.py that mis-assigned readmission labeler when long_los is specified.