### PR TITLE
Add a filter for excluded codes to `CountFeaturizer`

### DIFF
--- a/src/femr/models/dataloader.py
+++ b/src/femr/models/dataloader.py
@@ -199,11 +199,13 @@ def create_batches() -> None:
         dictionary = msgpack.load(f, use_list=False)
 
         if args.is_hierarchical:
-            dict_len = len(dictionary['ontology_rollup'])
+            dict_len = len(dictionary["ontology_rollup"])
         else:
-            dict_len = len(dictionary['regular'])
+            dict_len = len(dictionary["regular"])
 
-        assert args.transformer_vocab_size <= dict_len, f"Transformer vocab size ({args.transformer_vocab_size}) must be <= len(dictionary) ({dict_len})"
+        assert (
+            args.transformer_vocab_size <= dict_len
+        ), f"Transformer vocab size ({args.transformer_vocab_size}) must be <= len(dictionary) ({dict_len})"
 
     data = femr.datasets.PatientDatabase(args.data_path)
 

--- a/tests/featurizers/test_featurizers.py
+++ b/tests/featurizers/test_featurizers.py
@@ -124,6 +124,33 @@ def test_count_featurizer(tmp_path: pathlib.Path):
         3,
     )
     _assert_featurized_patients_structure(labeled_patients, featurized_patients, labels_per_patient)
+    patient: femr.Patient = cast(femr.Patient, database[0])
+    labels = labeler.label(patient)
+    featurizer = CountFeaturizer(exclusion_criteria={get_femr_code(ontology, 2)})
+    featurizer.preprocess(patient, labels)
+
+    assert featurizer.get_num_columns() == 2, f"featurizer.get_num_columns() = {featurizer.get_num_columns()}"
+
+
+def test_count_featurizer_filter(tmp_path: pathlib.Path):
+    time_horizon = TimeHorizon(datetime.timedelta(days=0), datetime.timedelta(days=180))
+    create_database(tmp_path)
+
+    database_path = os.path.join(tmp_path, "target")
+    database = femr.datasets.PatientDatabase(database_path)
+    ontology = database.get_ontology()
+
+    femr_outcome_code = get_femr_code(ontology, 2)
+    femr_admission_code = get_femr_code(ontology, 3)
+
+    labeler = CodeLabeler([femr_outcome_code], time_horizon, [femr_admission_code])
+
+    patient: femr.Patient = cast(femr.Patient, database[0])
+    labels = labeler.label(patient)
+    featurizer = CountFeaturizer(exclusion_criteria={get_femr_code(ontology, 2)})
+    featurizer.preprocess(patient, labels)
+
+    assert featurizer.get_num_columns() == 2, f"featurizer.get_num_columns() = {featurizer.get_num_columns()}"
 
 
 def test_count_bins_featurizer(tmp_path: pathlib.Path):

--- a/tests/featurizers/test_featurizers.py
+++ b/tests/featurizers/test_featurizers.py
@@ -154,9 +154,9 @@ def test_count_bins_featurizer(tmp_path: pathlib.Path):
     featurizer.preprocess(patient, labels)
     patient_features = featurizer.featurize(patient, labels, ontology)
 
-    included_codes = set([e.code for e in patient.events if e.value is None])
+    exact_codes_set = set([e.code for e in patient.events if e.value is None])
 
-    assert featurizer.included_codes == included_codes, f"featurizer.included_codes = {featurizer.included_codes}"
+    assert featurizer.exact_codes_set == exact_codes_set, f"featurizer.exact_codes_set = {featurizer.exact_codes_set}"
     assert featurizer.get_num_columns() == 9, f"featurizer.get_num_columns() = {featurizer.get_num_columns()}"
 
     assert patient_features[0] == [


### PR DESCRIPTION
Attempts to resolve #106 -- adds a filter that adds extra logic on the specific int code (e.g. you can set a threshold, do arbitrary number things like check for even numbers, etc.)

Will probably need to revise this with more context as I get more familiar with the workflow -- lmk what you guys think!