### PR TITLE
Labelers update

### DIFF
--- a/src/femr/extractors/omop.py
+++ b/src/femr/extractors/omop.py
@@ -210,7 +210,7 @@ def get_omop_csv_extractors() -> Sequence[CSVExtractor]:
         ),
         _ConceptTableConverter(
             prefix="visit_detail",
-            concept_id_field="visit_detail_concept_id",
+            concept_id_field="femr_visit_detail_concept_id",
         ),
     ]
 

--- a/src/femr/extractors/omop.py
+++ b/src/femr/extractors/omop.py
@@ -210,7 +210,7 @@ def get_omop_csv_extractors() -> Sequence[CSVExtractor]:
         ),
         _ConceptTableConverter(
             prefix="visit_detail",
-            concept_id_field="femr_visit_detail_concept_id",
+            concept_id_field="visit_detail_concept_id",
         ),
     ]
 

--- a/src/femr/labelers/core.py
+++ b/src/femr/labelers/core.py
@@ -556,7 +556,7 @@ class NLabelsPerPatientLabeler(Labeler):
 
 
 def compute_random_num(seed: int, num_1: int, num_2: int):
-    network_num_1 = struct.pack("!I", num_1)
+    network_num_1 = struct.pack("!Q", num_1)
     network_num_2 = struct.pack("!I", num_2)
     network_seed = struct.pack("!I", seed)
 

--- a/src/femr/labelers/core.py
+++ b/src/femr/labelers/core.py
@@ -556,7 +556,7 @@ class NLabelsPerPatientLabeler(Labeler):
 
 
 def compute_random_num(seed: int, num_1: int, num_2: int):
-    network_num_1 = struct.pack("!Q", num_1)
+    network_num_1 = struct.pack("!q", num_1)
     network_num_2 = struct.pack("!q", num_2)
     network_seed = struct.pack("!q", seed)
 

--- a/src/femr/labelers/core.py
+++ b/src/femr/labelers/core.py
@@ -557,8 +557,8 @@ class NLabelsPerPatientLabeler(Labeler):
 
 def compute_random_num(seed: int, num_1: int, num_2: int):
     network_num_1 = struct.pack("!Q", num_1)
-    network_num_2 = struct.pack("!I", num_2)
-    network_seed = struct.pack("!I", seed)
+    network_num_2 = struct.pack("!q", num_2)
+    network_seed = struct.pack("!q", seed)
 
     to_hash = network_seed + network_num_1 + network_num_2
 

--- a/src/femr/labelers/omop.py
+++ b/src/femr/labelers/omop.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import datetime
+import warnings
 from abc import abstractmethod
 from collections import deque
 from typing import Any, Callable, List, Optional, Set, Tuple
@@ -113,7 +114,7 @@ def map_omop_concept_codes_to_femr_codes(
                 _get_all_children(ontology, omop_concept_code) if is_ontology_expansion else {omop_concept_code}
             )
         except IndexError:
-            raise ValueError(f"OMOP Concept Code {omop_concept_code} not found in ontology.")
+            warnings.warn(f"OMOP Concept Code {omop_concept_code} not found in ontology.")
     return codes
 
 

--- a/src/femr/labelers/omop_inpatient_admissions.py
+++ b/src/femr/labelers/omop_inpatient_admissions.py
@@ -228,7 +228,7 @@ class InpatientMortalityLabeler(WithinInpatientVisitLabeler):
         # For each visit, check if there is an outcome which occurs within the (start, end) of the visit
         for prediction_start, prediction_end in zip(prediction_start_times, prediction_end_times):
             # exclude if prediction time > discharge time
-            if prediction_start > prediction_end:
+            if prediction_start >= prediction_end:
                 continue
 
             # exclude if deathtime > discharge time

--- a/src/femr/labelers/omop_lab_values.py
+++ b/src/femr/labelers/omop_lab_values.py
@@ -139,6 +139,7 @@ class ThrombocytopeniaLabValueLabeler(InpatientLabValueLabeler):
     original_omop_concept_codes = [
         "LOINC/LP393218-5",
         "LOINC/LG32892-8",
+        "LOINC/777-3",
     ]
 
     def value_to_label(self, raw_value: str, unit: Optional[str]) -> str:
@@ -162,6 +163,8 @@ class HyperkalemiaLabValueLabeler(InpatientLabValueLabeler):
         "LOINC/LG7931-1",
         "LOINC/LP386618-5",
         "LOINC/LG10990-6",
+        "LOINC/6298-4",
+        "LOINC/2823-3",
     ]
 
     def value_to_label(self, raw_value: str, unit: Optional[str]) -> str:
@@ -202,6 +205,8 @@ class HypoglycemiaLabValueLabeler(InpatientLabValueLabeler):
     original_omop_concept_codes = [
         "SNOMED/33747003",
         "LOINC/LP416145-3",
+        "LOINC/14749-6",
+        "LOINC/15074-8",
     ]
 
     def value_to_label(self, raw_value: str, unit: Optional[str]) -> str:
@@ -235,9 +240,7 @@ class HyponatremiaLabValueLabeler(InpatientLabValueLabeler):
     """lab-based definition for hyponatremia based on blood sodium concentration (mmol/L).
     Thresholds: mild (<=135),moderate(<130),severe(<125), and abnormal range."""
 
-    original_omop_concept_codes = [
-        "LOINC/LG11363-5",
-    ]
+    original_omop_concept_codes = ["LOINC/LG11363-5", "LOINC/2951-2", "LOINC/2947-0"]
 
     def value_to_label(self, raw_value: str, unit: Optional[str]) -> str:
         if raw_value.lower() in ["normal", "adequate"]:
@@ -276,6 +279,8 @@ class AnemiaLabValueLabeler(InpatientLabValueLabeler):
                 # Original OMOP concept ID: 8840
                 # NOTE: This weird *10 / 100 is how Lawrence did it
                 value = value / 100
+            elif unit.startswith("g/l"):
+                value = value
             else:
                 raise ValueError(f"Unknown unit: {unit}")
         else:

--- a/src/femr/models/scripts.py
+++ b/src/femr/models/scripts.py
@@ -64,12 +64,12 @@ def train_model() -> None:
     parser.add_argument("--token_dropout", type=float, default=0)
     parser.add_argument("--internal_dropout", type=float, default=0)
     parser.add_argument("--weight_decay", type=float, default=0)
-    parser.add_argument("--max_iter", type=float, default=None)
-    parser.add_argument("--hidden_size", type=float, default=768, help="Transformer hidden size")
-    parser.add_argument("--intermediate_size", type=float, default=3072, help="Transformer intermediate layer size")
-    parser.add_argument("--n_heads", type=float, default=12, help="Transformer # of heads")
-    parser.add_argument("--n_layers", type=float, default=6, help="Transformer # of layers")
-    parser.add_argument("--attention_width", type=float, default=512, help="Transformer attention width.")
+    parser.add_argument("--max_iter", type=int, default=None)
+    parser.add_argument("--hidden_size", type=int, default=768, help="Transformer hidden size")
+    parser.add_argument("--intermediate_size", type=int, default=3072, help="Transformer intermediate layer size")
+    parser.add_argument("--n_heads", type=int, default=12, help="Transformer # of heads")
+    parser.add_argument("--n_layers", type=int, default=6, help="Transformer # of layers")
+    parser.add_argument("--attention_width", type=int, default=512, help="Transformer attention width.")
 
     parser.add_argument(
         "--early_stopping_window_steps",

--- a/tests/labelers/test_InpatientAdmissionLabelers.py
+++ b/tests/labelers/test_InpatientAdmissionLabelers.py
@@ -321,12 +321,15 @@ def test_mortality(tmp_path: pathlib.Path):
             (event((2001, 1, 1), "Visit/IP", end=datetime.datetime(2001, 1, 11), omop_table='visit_occurrence'), False),  # admission
             (event((2002, 1, 1), "Visit/IP", end=datetime.datetime(2002, 1, 11), omop_table='visit_occurrence'), True),  # admission
             (event((2002, 1, 10), outcome_code), "skip"),  # event
-            (event((2003, 1, 1), "Visit/IP", end=datetime.datetime(2003, 1, 11), omop_table='visit_occurrence'), "skip"),  # admission
+            (event((2003, 1, 1), "Visit/IP", end=datetime.datetime(2003, 1, 11), omop_table='visit_occurrence'), "skip"),
+            # admission
             # fmt: on
         ]
         assert labeler.outcome_codes == {"Condition Type/OMOP4822053", "Death Type/OMOP generated", "DEATH_CHILD"}
         true_prediction_times: List[datetime.datetime] = [
-            move_datetime_to_end_of_day(x[0].start) for x in events_with_labels if isinstance(x[1], bool) or x[1] is None
+            move_datetime_to_end_of_day(x[0].start)
+            for x in events_with_labels
+            if isinstance(x[1], bool) or x[1] is None
         ]
         run_test_for_labeler(
             labeler,

--- a/tests/labelers/test_LabValueLabelers.py
+++ b/tests/labelers/test_LabValueLabelers.py
@@ -344,8 +344,16 @@ def test_thrombocytopenia(tmp_path: pathlib.Path):
 
 
 def test_hyperkalemia(tmp_path: pathlib.Path):
-    outcome_codes = {"child_1_1", "child_2", "child_1", "LOINC/LP386618-5", "LOINC/LG10990-6", "LOINC/LG7931-1", "LOINC/6298-4",
-                    "LOINC/2823-3"}
+    outcome_codes = {
+        "child_1_1",
+        "child_2",
+        "child_1",
+        "LOINC/LP386618-5",
+        "LOINC/LG10990-6",
+        "LOINC/LG7931-1",
+        "LOINC/6298-4",
+        "LOINC/2823-3",
+    }
     labeler = _create_specific_labvalue_labeler(
         HyperkalemiaLabValueLabeler,
         "severe",
@@ -368,8 +376,15 @@ def test_hyperkalemia(tmp_path: pathlib.Path):
 
 
 def test_hypoglycemia(tmp_path: pathlib.Path):
-    outcome_codes = {"child_2", "child_1_1", "SNOMED/33747003", "LOINC/LP416145-3", "child_1", "LOINC/14749-6",
-                    "LOINC/15074-8"}
+    outcome_codes = {
+        "child_2",
+        "child_1_1",
+        "SNOMED/33747003",
+        "LOINC/LP416145-3",
+        "child_1",
+        "LOINC/14749-6",
+        "LOINC/15074-8",
+    }
     labeler = _create_specific_labvalue_labeler(
         HypoglycemiaLabValueLabeler,
         "severe",

--- a/tests/labelers/test_LabValueLabelers.py
+++ b/tests/labelers/test_LabValueLabelers.py
@@ -321,7 +321,7 @@ class DummyOntology_Specific:
 
 
 def test_thrombocytopenia(tmp_path: pathlib.Path):
-    outcome_codes = {"child_1", "child_1_1", "LOINC/LP393218-5", "LOINC/LG32892-8", "child_2"}
+    outcome_codes = {"child_1", "child_1_1", "LOINC/LP393218-5", "LOINC/LG32892-8", "child_2", "LOINC/777-3"}
     labeler = _create_specific_labvalue_labeler(
         ThrombocytopeniaLabValueLabeler,
         "severe",
@@ -344,7 +344,8 @@ def test_thrombocytopenia(tmp_path: pathlib.Path):
 
 
 def test_hyperkalemia(tmp_path: pathlib.Path):
-    outcome_codes = {"child_1_1", "child_2", "child_1", "LOINC/LP386618-5", "LOINC/LG10990-6", "LOINC/LG7931-1"}
+    outcome_codes = {"child_1_1", "child_2", "child_1", "LOINC/LP386618-5", "LOINC/LG10990-6", "LOINC/LG7931-1", "LOINC/6298-4",
+                    "LOINC/2823-3"}
     labeler = _create_specific_labvalue_labeler(
         HyperkalemiaLabValueLabeler,
         "severe",
@@ -367,7 +368,8 @@ def test_hyperkalemia(tmp_path: pathlib.Path):
 
 
 def test_hypoglycemia(tmp_path: pathlib.Path):
-    outcome_codes = {"child_2", "child_1_1", "SNOMED/33747003", "LOINC/LP416145-3", "child_1"}
+    outcome_codes = {"child_2", "child_1_1", "SNOMED/33747003", "LOINC/LP416145-3", "child_1", "LOINC/14749-6",
+                    "LOINC/15074-8"}
     labeler = _create_specific_labvalue_labeler(
         HypoglycemiaLabValueLabeler,
         "severe",
@@ -390,7 +392,7 @@ def test_hypoglycemia(tmp_path: pathlib.Path):
 
 
 def test_hyponatremia(tmp_path: pathlib.Path):
-    outcome_codes = {"child_1", "child_1_1", "LOINC/LG11363-5"}
+    outcome_codes = {"child_1", "child_1_1", "child_2", "LOINC/LG11363-5", "LOINC/2951-2", "LOINC/2947-0"}
     labeler = _create_specific_labvalue_labeler(
         HyponatremiaLabValueLabeler,
         "severe",


### PR DESCRIPTION
Labelers update:

`InpatientReadmissionLabeler` : exclude same-day readmissions since prediction time is by-default shifted to the end of the discharge day - adopted from [here](https://github.com/som-shahlab/femr/blob/6559ec50c275008cac60a471c07d73f848a944b6/src/piton/labelers/omop_inpatient_admissions.py#L113). 
`InpatientLongAdmissionLabeler`: exclude if discharge (for the same admission) or death occurred before prediction time
`InpatientMortalityLabeler`: exclude if discharge (for the same admission) or death occurred before prediction time
`ThrombocytopeniaLabValueLabeler`: add LOINC/777-3 to concept codes
`HyperkalemiaLabValueLabeler` add LOINC/6298-4 and LOINC/2823-3 to concept codes
`HypoglycemiaLabValueLabeler`: add LOINC/14749-6 and LOINC/15074-8 to concept codes
`HyponatremiaLabValueLabeler`: add LOINC/2951-2, and LOINC/2947-0 to concept codes
`AnemiaLabValueLabeler`:  add unit conversion for "g/L" 


Others:
`map_omop_concept_codes_to_femr_codes` issues warning instead of raising an exception when concept code is not referenced in the patient database. 
`compute_random_num`: allows 64-bit int