### PR TITLE
Add support for loading CSV of LabeledPatients

### DIFF
--- a/src/femr/labelers/__init__.py
+++ b/src/femr/labelers/__init__.py
@@ -3,3 +3,4 @@
 from __future__ import annotations
 
 from femr.labelers.core import *  # noqa
+from femr.labelers.omop import *  # noqa

--- a/src/femr/labelers/core.py
+++ b/src/femr/labelers/core.py
@@ -13,8 +13,8 @@ from collections.abc import MutableMapping
 from dataclasses import dataclass
 from typing import Any, DefaultDict, Dict, List, Literal, Optional, Sequence, Tuple, Union, cast
 
-import pandas as pd
 import numpy as np
+import pandas as pd
 from nptyping import NDArray
 
 from femr import Patient

--- a/src/femr/labelers/core.py
+++ b/src/femr/labelers/core.py
@@ -13,6 +13,7 @@ from collections.abc import MutableMapping
 from dataclasses import dataclass
 from typing import Any, DefaultDict, Dict, List, Literal, Optional, Sequence, Tuple, Union, cast
 
+import pandas as pd
 import numpy as np
 from nptyping import NDArray
 
@@ -571,3 +572,11 @@ def compute_random_num(seed: int, num_1: int, num_2: int):
         result = (result * 256 + hash_value[i]) % 100
 
     return result
+
+def load_labeled_patients_from_csv(path_to_csv: str, labeler_type: str) -> LabeledPatients:
+    """Load the CSV at `path_to_csv` into a LabeledPatient object and return it"""
+    df = pd.read_csv(path_to_csv)
+    patients_to_labels: Dict[int, List[Label]] = collections.defaultdict(list)
+    for idx, row in df.iterrows():
+        patients_to_labels[row['patient_id']].append(Label(time=row['prediction_time'], value=row['label_value']))
+    return LabeledPatients(patients_to_labels, labeler_type)

--- a/src/femr/labelers/core.py
+++ b/src/femr/labelers/core.py
@@ -573,10 +573,11 @@ def compute_random_num(seed: int, num_1: int, num_2: int):
 
     return result
 
-def load_labeled_patients_from_csv(path_to_csv: str, labeler_type: str) -> LabeledPatients:
+def load_labeled_patients_from_csv(path_to_csv: str) -> LabeledPatients:
     """Load the CSV at `path_to_csv` into a LabeledPatient object and return it"""
     df = pd.read_csv(path_to_csv)
     patients_to_labels: Dict[int, List[Label]] = collections.defaultdict(list)
     for idx, row in df.iterrows():
+        labeler_type: str = row['label_type']
         patients_to_labels[row['patient_id']].append(Label(time=row['prediction_datetime'], value=row['label_value']))
     return LabeledPatients(patients_to_labels, labeler_type)

--- a/src/femr/labelers/core.py
+++ b/src/femr/labelers/core.py
@@ -578,5 +578,5 @@ def load_labeled_patients_from_csv(path_to_csv: str, labeler_type: str) -> Label
     df = pd.read_csv(path_to_csv)
     patients_to_labels: Dict[int, List[Label]] = collections.defaultdict(list)
     for idx, row in df.iterrows():
-        patients_to_labels[row['patient_id']].append(Label(time=row['prediction_time'], value=row['label_value']))
+        patients_to_labels[row['patient_id']].append(Label(time=row['prediction_datetime'], value=row['label_value']))
     return LabeledPatients(patients_to_labels, labeler_type)

--- a/src/femr/models/dataloader.py
+++ b/src/femr/models/dataloader.py
@@ -18,6 +18,7 @@ import numpy as np
 
 import femr.datasets
 import femr.extension.dataloader
+from femr.labelers.core import LabeledPatients, load_labeled_patients_from_csv
 
 T = TypeVar("T")
 
@@ -171,7 +172,8 @@ def create_batches() -> None:
     parser.add_argument(
         "--clmbr_survival_dictionary_path", type=str, help="The survival clmbr dictionary if running that task"
     )
-    parser.add_argument("--labeled_patients_path", type=str, help="The labeled patients")
+    parser.add_argument("--labeled_patients_path", type=str, help="Path to file containing labeled patients. Can be either .csv or .pkl")
+    parser.add_argument("--labeler_type", type=str, help="LabelType of the labeler being loaded.")
     parser.add_argument(
         "--is_hierarchical", default=False, action="store_true", help="Whether to use hierarchical embeddings"
     )
@@ -236,8 +238,10 @@ def create_batches() -> None:
     data = femr.datasets.PatientDatabase(args.data_path)
 
     if args.labeled_patients_path is not None:
-        with open(args.labeled_patients_path, "rb") as f:
-            labeled_patients = pickle.load(f)
+        assert args.labeled_patients_path.endswith(".pkl") or args.labeled_patients_path.endswith(".csv"), "Labeled patients path must be either .pkl or .csv"
+        is_labeled_patients_pkl: bool = args.labeled_patients_path.endswith(".pkl")
+        with open(args.labeled_patients_path, "rb" if is_labeled_patients_pkl else "r") as f:
+            labeled_patients: LabeledPatients = pickle.load(f) if is_labeled_patients_pkl else load_labeled_patients_from_csv(args.labeled_patients_path, args.labeler_type)
             result_labels = []
             offsets = []
             total_events = 0

--- a/src/femr/models/dataloader.py
+++ b/src/femr/models/dataloader.py
@@ -173,7 +173,6 @@ def create_batches() -> None:
         "--clmbr_survival_dictionary_path", type=str, help="The survival clmbr dictionary if running that task"
     )
     parser.add_argument("--labeled_patients_path", type=str, help="Path to file containing labeled patients. Can be either .csv or .pkl")
-    parser.add_argument("--labeler_type", type=str, help="LabelType of the labeler being loaded.")
     parser.add_argument(
         "--is_hierarchical", default=False, action="store_true", help="Whether to use hierarchical embeddings"
     )
@@ -241,7 +240,7 @@ def create_batches() -> None:
         assert args.labeled_patients_path.endswith(".pkl") or args.labeled_patients_path.endswith(".csv"), "Labeled patients path must be either .pkl or .csv"
         is_labeled_patients_pkl: bool = args.labeled_patients_path.endswith(".pkl")
         with open(args.labeled_patients_path, "rb" if is_labeled_patients_pkl else "r") as f:
-            labeled_patients: LabeledPatients = pickle.load(f) if is_labeled_patients_pkl else load_labeled_patients_from_csv(args.labeled_patients_path, args.labeler_type)
+            labeled_patients: LabeledPatients = pickle.load(f) if is_labeled_patients_pkl else load_labeled_patients_from_csv(args.labeled_patients_path)
             result_labels = []
             offsets = []
             total_events = 0

--- a/src/femr/models/dataloader.py
+++ b/src/femr/models/dataloader.py
@@ -237,10 +237,20 @@ def create_batches() -> None:
     data = femr.datasets.PatientDatabase(args.data_path)
 
     if args.labeled_patients_path is not None:
-        assert args.labeled_patients_path.endswith(".pkl") or args.labeled_patients_path.endswith(".csv"), "Labeled patients path must be either .pkl or .csv"
+        assert args.labeled_patients_path.endswith(".pkl") or args.labeled_patients_path.endswith(
+            ".csv"
+        ), "Labeled patients path must be either .pkl or .csv"
         is_labeled_patients_pkl: bool = args.labeled_patients_path.endswith(".pkl")
         with open(args.labeled_patients_path, "rb" if is_labeled_patients_pkl else "r") as f:
+<<<<<<< HEAD
             labeled_patients: LabeledPatients = pickle.load(f) if is_labeled_patients_pkl else load_labeled_patients_from_csv(args.labeled_patients_path)
+=======
+            labeled_patients: LabeledPatients = (
+                pickle.load(f)
+                if is_labeled_patients_pkl
+                else load_labeled_patients_from_csv(args.labeled_patients_path, args.labeler_type)
+            )
+>>>>>>> fd971ad383f424b2d10131c89783af86ae8e508b
             result_labels = []
             offsets = []
             total_events = 0

--- a/src/femr/models/scripts.py
+++ b/src/femr/models/scripts.py
@@ -627,7 +627,7 @@ def compute_representations() -> None:
 
     patient_labels = collections.defaultdict(list)
 
-    for pid, age, label in batch_info['config']['task']['labels']:
+    for pid, age, label in batch_info["config"]["task"]["labels"]:
         patient_labels[pid].append((age, label))
 
     loader = femr.extension.dataloader.BatchLoader(args.data_path, batch_info_path)
@@ -680,7 +680,6 @@ def compute_representations() -> None:
 
     assert set(results.keys()) == set(patient_labels.keys())
 
-
     label_times = []
     data_matrix = []
     label_pids = []
@@ -707,7 +706,7 @@ def compute_representations() -> None:
                 next_repr_index = current_repr_index + 1
                 if next_repr_index >= len(representations):
                     break
-                
+
                 next_time = representations[next_repr_index][0]
                 if next_time > label_age:
                     break


### PR DESCRIPTION
Updates the `clmbr_create_batches` dataloader to accept a CSV representing labels instead of a `.pkl` dump of a `LabeledPatients` object.

This is part of the "simple FEMR CSV" pipeline.

The CSV is expected to have these columns: **patient_id, prediction_datetime, label_value**. This new code allows the dataloader to directly load that CSV into a `LabeledPatient` object, rather than requiring the end user to first create a `LabeledPatient` object and then dump it to a `.pkl` file