### PR TITLE
Start the deprecation of femr_visit_detail_concept_id

### DIFF
--- a/src/femr/extractors/omop.py
+++ b/src/femr/extractors/omop.py
@@ -211,8 +211,6 @@ def get_omop_csv_extractors() -> Sequence[CSVExtractor]:
         ),
         _ConceptTableConverter(
             prefix="visit_detail",
-            # concept_id_field="piton_visit_detail_concept_id",
-            concept_id_field="femr_visit_detail_concept_id",
         ),
     ]
 

--- a/tools/omop/normalize_visit_detail.py
+++ b/tools/omop/normalize_visit_detail.py
@@ -2,6 +2,8 @@
 A handy tool for adding a visit_detail_concept_id to the visit_detail table.
 
 This makes visit_detail a "standard concept" table, which means it can be processed like many other OMOP tables.
+
+TODO: Deprecate this transformation because it violates OMOP assumptions in confusing ways.
 """
 
 import argparse
@@ -41,9 +43,9 @@ def get_care_site_concepts(root: str, child: str) -> Mapping[str, Tuple[str, Opt
 def convert_row(row: Mapping[str, str], care_site_concepts: Mapping[str, str]) -> Mapping[str, str]:
     result = dict(**row)
     if row["care_site_id"] == "":
-        result["femr_visit_detail_concept_id"] = "0"
+        result["visit_detail_concept_id"] = "0"
     else:
-        result["femr_visit_detail_concept_id"] = care_site_concepts[row["care_site_id"]]
+        result["visit_detail_concept_id"] = care_site_concepts[row["care_site_id"]]
     return result
 
 
@@ -55,7 +57,7 @@ def correct_rows(root: str, target: str, care_site_concepts: Mapping[str, str], 
         with io.TextIOWrapper(zstandard.ZstdCompressor(1).stream_writer(open(out_path, "wb"))) as o:
             reader = csv.DictReader(f)
             assert reader.fieldnames is not None
-            writer = csv.DictWriter(o, list(reader.fieldnames) + ["femr_visit_detail_concept_id"])
+            writer = csv.DictWriter(o, list(reader.fieldnames))
             writer.writeheader()
             for row in reader:
                 new_row = convert_row(row, care_site_concepts)


### PR DESCRIPTION
femr_visit_detail_concept_id was a hack to work around deficient visit_detail_concept_ids in STARR-OMOP.

The time for this hack appears to be at an end since this is now fixed upstream of STARR-OMOP and this transform is now throwing away useful information.

This will also improve OMOP compliance and make this library easier to use for people used to OMOP.

normalize_visit_detail.py is now optional and will be removed once I fix some more things on the STARR-OMOP side.

Fixes #149