### PR TITLE
Rework death

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 The currently supported foundation models are [CLMBR](https://arxiv.org/pdf/2001.05295.pdf) and [MOTOR](https://arxiv.org/abs/2301.03150).
 
-**FEMR** by default supports the [OMOP Common Data Model](https://www.ohdsi.org/data-standardization/) developed by the OHDSI community, but can also be used with other forms of EHR / claims data with minimal processing.  **FEMR** has been used to process data from a variety of sources, including MIMIC-IV, Optum, Truven, STARR-OMOP, and SickKids-OMOP. 
+**FEMR** by default supports the [OMOP Common Data Model](https://www.ohdsi.org/data-standardization/) developed by the OHDSI community, but can also be used with other forms of EHR / claims data with minimal processing.  **FEMR** has been used to process data from a variety of sources, including MIMIC-IV, Optum, Truven, STARR-OMOP, and SickKids-OMOP.
 
 **FEMR** helps users:
 1. [Manipulate events in the EHR data comprising a patient's timeline](https://github.com/som-shahlab/femr/blob/main/tutorials/1_Overview.ipynb)

--- a/src/femr/extractors/omop.py
+++ b/src/femr/extractors/omop.py
@@ -10,6 +10,7 @@ from femr.datasets import RawEvent
 from femr.extractors.csv import CSVExtractor
 
 OMOP_BIRTH = 4216316
+OMOP_DEATH = 4306655
 
 
 class _DemographicsConverter(CSVExtractor):
@@ -46,7 +47,7 @@ class _DemographicsConverter(CSVExtractor):
             # 4216316 is the OMOP birth code
             RawEvent(
                 start=birth,
-                concept_id=4216316,
+                concept_id=OMOP_BIRTH,
                 omop_table="person",
                 clarity_table=row.get("load_table_id"),
             )
@@ -95,6 +96,7 @@ class _ConceptTableConverter(CSVExtractor):
     concept_id_field: Optional[str] = None
     string_value_field: Optional[str] = None
     numeric_value_field: Optional[str] = None
+    force_concept_id: Optional[int] = None
 
     def get_patient_id_field(self) -> str:
         return "person_id"
@@ -116,8 +118,12 @@ class _ConceptTableConverter(CSVExtractor):
         value = normalize_to_float_if_possible(self.string_value_field, None)
         value = normalize_to_float_if_possible(self.numeric_value_field, value)
 
-        concept_id_field = self.concept_id_field or (self.prefix + "_concept_id")
-        concept_id = int(row[concept_id_field])
+        if self.force_concept_id is not None:
+            concept_id = self.force_concept_id
+        else:
+            concept_id_field = self.concept_id_field or (self.prefix + "_concept_id")
+            concept_id = int(row[concept_id_field])
+
         if concept_id == 0:
             # The following are worth recovering even without the code ...
             if self.prefix == "note":
@@ -164,10 +170,11 @@ class _ConceptTableConverter(CSVExtractor):
         if unit is not None:
             metadata["unit"] = unit
 
-        source_code_column = concept_id_field.replace("_concept_id", "_source_value")
-        source_code = row.get(source_code_column)
-        if source_code is not None:
-            metadata["source_code"] = source_code
+        if self.force_concept_id is None:
+            source_code_column = concept_id_field.replace("_concept_id", "_source_value")
+            source_code = row.get(source_code_column)
+            if source_code is not None:
+                metadata["source_code"] = source_code
 
         return [RawEvent(start=start, concept_id=concept_id, value=value, **metadata)]
 
@@ -188,7 +195,7 @@ def get_omop_csv_extractors() -> Sequence[CSVExtractor]:
             prefix="condition",
             file_suffix="occurrence",
         ),
-        _ConceptTableConverter(prefix="death", concept_id_field="death_type_concept_id"),
+        _ConceptTableConverter(prefix="death", force_concept_id=OMOP_DEATH,),
         _ConceptTableConverter(
             prefix="procedure",
             file_suffix="occurrence",

--- a/src/femr/extractors/omop.py
+++ b/src/femr/extractors/omop.py
@@ -195,7 +195,10 @@ def get_omop_csv_extractors() -> Sequence[CSVExtractor]:
             prefix="condition",
             file_suffix="occurrence",
         ),
-        _ConceptTableConverter(prefix="death", force_concept_id=OMOP_DEATH,),
+        _ConceptTableConverter(
+            prefix="death",
+            force_concept_id=OMOP_DEATH,
+        ),
         _ConceptTableConverter(
             prefix="procedure",
             file_suffix="occurrence",

--- a/src/femr/labelers/omop.py
+++ b/src/femr/labelers/omop.py
@@ -27,7 +27,6 @@ def get_inpatient_admission_concepts() -> List[str]:
 def get_death_concepts() -> List[str]:
     return [
         "SNOMED/419620001",
-
         # The folowing 2 are deprecated and will be removed once v8 is no longer in service
         "Death Type/OMOP generated",
         "Condition Type/OMOP4822053",

--- a/src/femr/labelers/omop.py
+++ b/src/femr/labelers/omop.py
@@ -26,6 +26,9 @@ def get_inpatient_admission_concepts() -> List[str]:
 
 def get_death_concepts() -> List[str]:
     return [
+        "SNOMED/419620001",
+
+        # The folowing 2 are deprecated and will be removed once v8 is no longer in service
         "Death Type/OMOP generated",
         "Condition Type/OMOP4822053",
     ]

--- a/tests/labelers/test_CodeLabelers.py
+++ b/tests/labelers/test_CodeLabelers.py
@@ -263,6 +263,7 @@ class DummyOntology_Mortality:
 
 def test_death_concepts() -> None:
     expected_death_concepts: set = {
+        "SNOMED/419620001",
         "Death Type/OMOP generated",
         "Condition Type/OMOP4822053",
     }
@@ -276,14 +277,14 @@ def test_MortalityCodeLabeler() -> None:
         (event((1995, 1, 3), 0, 34.5), False),
         (event((2000, 1, 1), 1, "test_value"), True),
         (event((2000, 1, 5), 2, 1), True),
-        (event((2000, 6, 5), "Condition Type/OMOP4822053", True), "skip"),
+        (event((2000, 6, 5), "SNOMED/419620001", True), "skip"),
         (event((2005, 2, 5), 2, None), False),
         (event((2005, 7, 5), 2, None), False),
         (event((2010, 10, 5), 1, None), False),
         (event((2015, 2, 5, 0), 2, None), False),
         (event((2015, 7, 5, 0), 0, None), True),
         (event((2015, 11, 5, 10, 10), 2, None), True),
-        (event((2015, 11, 15, 11), "Death Type/OMOP generated", None), "skip"),
+        (event((2015, 11, 15, 11), "SNOMED/419620001", None), "skip"),
         (event((2020, 1, 1), 2, None), "out of range"),
         (event((2020, 3, 1, 10, 10, 10), 2, None), "out of range"),
     ]
@@ -294,7 +295,7 @@ def test_MortalityCodeLabeler() -> None:
     labeler = MortalityCodeLabeler(ontology, time_horizon)  # type: ignore
 
     # Check that we selected the right codes
-    assert set(labeler.outcome_codes) == {"Death Type/OMOP generated", "Condition Type/OMOP4822053"}
+    assert set(labeler.outcome_codes) == {"Death Type/OMOP generated", "Condition Type/OMOP4822053", "SNOMED/419620001"}
 
     run_test_for_labeler(labeler, events_with_labels, help_text="MortalityLabeler")
 

--- a/tests/labelers/test_InpatientAdmissionLabelers.py
+++ b/tests/labelers/test_InpatientAdmissionLabelers.py
@@ -304,7 +304,7 @@ def test_readmission(tmp_path: pathlib.Path):
 
 class DummyMortalityOntology:
     def get_children(self, code: str) -> List[str]:
-        if code == "Death Type/OMOP generated":
+        if code == "SNOMED/419620001":
             return ["DEATH_CHILD"]
         return []
 
@@ -312,7 +312,7 @@ class DummyMortalityOntology:
 def test_mortality(tmp_path: pathlib.Path):
     ontology = DummyMortalityOntology()
     labeler = InpatientMortalityLabeler(ontology)  # type: ignore
-    for outcome_code in ["Death Type/OMOP generated", "DEATH_CHILD", "Condition Type/OMOP4822053"]:
+    for outcome_code in ["SNOMED/419620001", "DEATH_CHILD"]:
         events_with_labels: EventsWithLabels = [
             # fmt: off
             #
@@ -325,7 +325,7 @@ def test_mortality(tmp_path: pathlib.Path):
             # admission
             # fmt: on
         ]
-        assert labeler.outcome_codes == {"Condition Type/OMOP4822053", "Death Type/OMOP generated", "DEATH_CHILD"}
+        assert labeler.outcome_codes == {"Condition Type/OMOP4822053", "Death Type/OMOP generated", "DEATH_CHILD", "SNOMED/419620001"}
         true_prediction_times: List[datetime.datetime] = [
             move_datetime_to_end_of_day(x[0].start)
             for x in events_with_labels

--- a/tests/labelers/test_InpatientAdmissionLabelers.py
+++ b/tests/labelers/test_InpatientAdmissionLabelers.py
@@ -325,7 +325,12 @@ def test_mortality(tmp_path: pathlib.Path):
             # admission
             # fmt: on
         ]
-        assert labeler.outcome_codes == {"Condition Type/OMOP4822053", "Death Type/OMOP generated", "DEATH_CHILD", "SNOMED/419620001"}
+        assert labeler.outcome_codes == {
+            "Condition Type/OMOP4822053",
+            "Death Type/OMOP generated",
+            "DEATH_CHILD",
+            "SNOMED/419620001",
+        }
         true_prediction_times: List[datetime.datetime] = [
             move_datetime_to_end_of_day(x[0].start)
             for x in events_with_labels


### PR DESCRIPTION
The current handling of death is both OMOP-noncomplaint and bad. It incorrectly relies on the death_concept_type_id being death related, which is not per the OMOP spec and thus doesn't work on datasets such as MIMIC-IV.

This fixes the code so it no longer relies on death_concept_type_id and instead uses an OMOP code for death: https://www.findacode.com/snomed/419620001--death.html

Fixes #154