### PR TITLE
mimic etl: move billing codes to visit end

### DIFF
--- a/src/femr/etl_pipelines/mimic.py
+++ b/src/femr/etl_pipelines/mimic.py
@@ -15,7 +15,7 @@ from femr.datasets import EventCollection, PatientCollection, RawEvent, RawPatie
 from femr.extractors.csv import run_csv_extractors
 from femr.extractors.omop import get_omop_csv_extractors
 from femr.transforms import delta_encode, remove_nones
-from femr.transforms.mimic import move_early_end_date_to_start_date
+from femr.transforms.mimic import move_billing_codes, move_early_end_date_to_start_date
 from femr.transforms.stanford import move_pre_birth, move_to_day_end, move_visit_start_to_first_event_start
 
 
@@ -26,9 +26,9 @@ def _is_visit_event(e: RawEvent) -> bool:
 def _get_mimic_transformations() -> Sequence[Callable[[RawPatient], Optional[RawPatient]]]:
     """Get the list of current OMOP transformations."""
     # All of these transformations are information preserving except
-    # replace_categorical_measurement_results
     transforms: Sequence[Callable[[RawPatient], Optional[RawPatient]]] = [
         move_pre_birth,
+        move_billing_codes,
         move_visit_start_to_first_event_start,
         move_early_end_date_to_start_date,
         move_to_day_end,

--- a/src/femr/transforms/mimic.py
+++ b/src/femr/transforms/mimic.py
@@ -1,4 +1,6 @@
 """Transforms that are unique to MIMIC OMOP."""
+import datetime
+from typing import Dict, List
 
 from femr.datasets import RawPatient
 
@@ -13,5 +15,49 @@ def move_early_end_date_to_start_date(patient: RawPatient) -> RawPatient:
     for event in patient.events:
         if event.end is not None and event.omop_table == "visit_occurrence" and event.end < event.start:
             event.end = event.start
+
+    return patient
+
+
+def move_billing_codes(patient: RawPatient) -> RawPatient:
+    """Move billing codes to the end of each visit.
+
+    One issue with MIMIC is that billing codes are assigned at the start of the visit.
+    This class fixes that by assigning them to the end of the visit.
+    """
+    visit_starts: Dict[int, datetime.datetime] = {}
+    visit_ends: Dict[int, datetime.datetime] = {}
+    tables_w_billing_codes: List[str] = ["condition_occurrence", "procedure_occurrence", "observation"]
+
+    for event in patient.events:
+        if event.omop_table == "visit_occurrence" and event.visit_id is not None:
+            if event.start is None or event.end is None:
+                raise RuntimeError(f"Missing visit start/end time for visit_occurrence_id {event.visit_id}")
+
+            visit_starts[event.visit_id] = event.start
+            visit_ends[event.visit_id] = event.end
+
+    new_events = []
+    for event in patient.events:
+        if event.omop_table in tables_w_billing_codes and event.visit_id is not None:
+            visit_start = visit_starts.get(event.visit_id)
+
+            if event.start == visit_start:
+                visit_end = visit_ends.get(event.visit_id)
+                event.start = visit_end  # type: ignore
+
+                if event.end is not None:
+                    event.end = max(event.end, visit_end)
+
+                new_events.append(event)
+
+            else:
+                new_events.append(event)
+
+        else:
+            new_events.append(event)
+
+    patient.events = new_events
+    patient.resort()
 
     return patient


### PR DESCRIPTION
billing codes seem to exist in `procedure_occurrence`, `condition_occurrence`, and `observation` - i.e., events have same start as visit. These events are now moved to visit end. 