### PR TITLE
change concept_id_value_field from "value_as_concept_id" to "observation_concept_id"

### DIFF
--- a/src/femr/extractors/omop.py
+++ b/src/femr/extractors/omop.py
@@ -247,13 +247,13 @@ def get_omop_csv_extractors() -> Sequence[CSVExtractor]:
             prefix="measurement",
             string_value_field="value_source_value",
             numeric_value_field="value_as_number",
-            concept_id_value_field="value_as_concept_id",
+            concept_id_value_field="observation_concept_id",
         ),
         _ConceptTableConverter(
             prefix="observation",
             string_value_field="value_as_string",
             numeric_value_field="value_as_number",
-            concept_id_value_field="value_as_concept_id",
+            concept_id_value_field="observation_concept_id",
         ),
         _ConceptTableConverter(
             prefix="note",


### PR DESCRIPTION
Running the tutorial notebook [2a_OMOP_ETL.ipynb](https://github.com/som-shahlab/femr/blob/main/tutorials/2a_OMOP_ETL.ipynb) I ran into a problem when calling `etl_generic_omop`. Apparently, it expects a column named `value_as_concept_id` in the observation .csv files:

```Python
Could not find any files for extractor _ConceptTableConverter(prefix='drug_exposure', file_suffix='', concept_id_field='drug_concept_id', string_value_field=None, numeric_value_field=None, concept_id_value_field=None, force_concept_id=None)
Could not find any files for extractor _ConceptTableConverter(prefix='visit', file_suffix='occurrence', concept_id_field=None, string_value_field=None, numeric_value_field=None, concept_id_value_field=None, force_concept_id=None)
Could not find any files for extractor _ConceptTableConverter(prefix='condition', file_suffix='occurrence', concept_id_field=None, string_value_field=None, numeric_value_field=None, concept_id_value_field=None, force_concept_id=None)
Could not find any files for extractor _ConceptTableConverter(prefix='death', file_suffix='', concept_id_field=None, string_value_field=None, numeric_value_field=None, concept_id_value_field=None, force_concept_id=4306655)
Could not find any files for extractor _ConceptTableConverter(prefix='procedure', file_suffix='occurrence', concept_id_field=None, string_value_field=None, numeric_value_field=None, concept_id_value_field=None, force_concept_id=None)
Could not find any files for extractor _ConceptTableConverter(prefix='device_exposure', file_suffix='', concept_id_field='device_concept_id', string_value_field=None, numeric_value_field=None, concept_id_value_field=None, force_concept_id=None)
Could not find any files for extractor _ConceptTableConverter(prefix='measurement', file_suffix='', concept_id_field=None, string_value_field='value_source_value', numeric_value_field='value_as_number', concept_id_value_field='value_as_concept_id', force_concept_id=None)
Could not find any files for extractor _ConceptTableConverter(prefix='note', file_suffix='', concept_id_field='note_class_concept_id', string_value_field='note_text', numeric_value_field=None, concept_id_value_field=None, force_concept_id=None)
Could not find any files for extractor _ConceptTableConverter(prefix='visit_detail', file_suffix='', concept_id_field=None, string_value_field=None, numeric_value_field=None, concept_id_value_field=None, force_concept_id=None)
2024-02-13 15:31:46,881 [MainThread  ] [INFO ]  Extracting from OMOP with arguments Namespace(omop_source='input/omop', target_location='/fh/fast/setty_m/user/dotto/femr/tutorials/trash/tutorial_2a/extract', temp_location='/fh/fast/setty_m/user/dotto/femr/tutorials/trash/tutorial_2a/logs', num_threads=2)
2024-02-13 15:31:46,882 [MainThread  ] [INFO ]  Converting to events
/fh/fast/setty_m/user/dotto/mamba/envs/EHRSHOT_ENV_3/lib/python3.10/site-packages/femr/datasets/fileio.py:71: UserWarning: Zero rows were written by the `EventWriter` for file: /fh/fast/setty_m/user/dotto/femr/tutorials/trash/tutorial_2a/logs/events/tmp1699poyg.csv.zst
  warnings.warn(f"Zero rows were written by the `EventWriter` for file: {self.file.name}")
2024-02-13 15:31:46,899 [MainThread  ] [ERROR]  Failing on input/omop/observation/9.csv _ConceptTableConverter(prefix='observation', file_suffix='', concept_id_field=None, string_value_field='value_as_string', numeric_value_field='value_as_number', concept_id_value_field='value_as_concept_id', force_concept_id=None)
/fh/fast/setty_m/user/dotto/mamba/envs/EHRSHOT_ENV_3/lib/python3.10/site-packages/femr/datasets/fileio.py:71: UserWarning: Zero rows were written by the `EventWriter` for file: /fh/fast/setty_m/user/dotto/femr/tutorials/trash/tutorial_2a/logs/events/tmpdq2dx6n_.csv.zst
  warnings.warn(f"Zero rows were written by the `EventWriter` for file: {self.file.name}")
2024-02-13 15:31:46,902 [MainThread  ] [ERROR]  Failing on input/omop/observation/6.csv _ConceptTableConverter(prefix='observation', file_suffix='', concept_id_field=None, string_value_field='value_as_string', numeric_value_field='value_as_number', concept_id_value_field='value_as_concept_id', force_concept_id=None)
2024-02-13 15:31:46,905 [MainThread  ] [CRITI]  'value_as_concept_id'
multiprocessing.pool.RemoteTraceback: 
"""
Traceback (most recent call last):
  File "/fh/fast/setty_m/user/dotto/mamba/envs/EHRSHOT_ENV_3/lib/python3.10/multiprocessing/pool.py", line 125, in worker
    result = (True, func(*args, **kwds))
  File "/fh/fast/setty_m/user/dotto/mamba/envs/EHRSHOT_ENV_3/lib/python3.10/site-packages/femr/extractors/csv.py", line 111, in _run_csv_extractor
    raise e
  File "/fh/fast/setty_m/user/dotto/mamba/envs/EHRSHOT_ENV_3/lib/python3.10/site-packages/femr/extractors/csv.py", line 73, in _run_csv_extractor
    events = extractor.get_events(lower_row)
  File "/fh/fast/setty_m/user/dotto/mamba/envs/EHRSHOT_ENV_3/lib/python3.10/site-packages/femr/extractors/omop.py", line 131, in get_events
    concept_id_value = _try_numeric(row[self.concept_id_value_field])
KeyError: 'value_as_concept_id'
"""

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/fh/fast/setty_m/user/dotto/mamba/envs/EHRSHOT_ENV_3/lib/python3.10/site-packages/femr/etl_pipelines/omop.py", line 93, in etl_generic_omop_program
    event_collection = run_csv_extractors(
  File "/fh/fast/setty_m/user/dotto/mamba/envs/EHRSHOT_ENV_3/lib/python3.10/site-packages/femr/extractors/csv.py", line 180, in run_csv_extractors
    for prefix, s in pool.imap_unordered(_run_csv_extractor, to_process):
  File "/fh/fast/setty_m/user/dotto/mamba/envs/EHRSHOT_ENV_3/lib/python3.10/multiprocessing/pool.py", line 873, in next
    raise value
KeyError: 'value_as_concept_id'
multiprocessing.pool.RemoteTraceback: 
"""
Traceback (most recent call last):
  File "/fh/fast/setty_m/user/dotto/mamba/envs/EHRSHOT_ENV_3/lib/python3.10/multiprocessing/pool.py", line 125, in worker
    result = (True, func(*args, **kwds))
  File "/fh/fast/setty_m/user/dotto/mamba/envs/EHRSHOT_ENV_3/lib/python3.10/site-packages/femr/extractors/csv.py", line 111, in _run_csv_extractor
    raise e
  File "/fh/fast/setty_m/user/dotto/mamba/envs/EHRSHOT_ENV_3/lib/python3.10/site-packages/femr/extractors/csv.py", line 73, in _run_csv_extractor
    events = extractor.get_events(lower_row)
  File "/fh/fast/setty_m/user/dotto/mamba/envs/EHRSHOT_ENV_3/lib/python3.10/site-packages/femr/extractors/omop.py", line 131, in get_events
    concept_id_value = _try_numeric(row[self.concept_id_value_field])
KeyError: 'value_as_concept_id'
"""

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/fh/fast/setty_m/user/dotto/mamba/envs/EHRSHOT_ENV_3/bin/etl_generic_omop", line 8, in <module>
    sys.exit(etl_generic_omop_program())
  File "/fh/fast/setty_m/user/dotto/mamba/envs/EHRSHOT_ENV_3/lib/python3.10/site-packages/femr/etl_pipelines/omop.py", line 148, in etl_generic_omop_program
    raise e
  File "/fh/fast/setty_m/user/dotto/mamba/envs/EHRSHOT_ENV_3/lib/python3.10/site-packages/femr/etl_pipelines/omop.py", line 93, in etl_generic_omop_program
    event_collection = run_csv_extractors(
  File "/fh/fast/setty_m/user/dotto/mamba/envs/EHRSHOT_ENV_3/lib/python3.10/site-packages/femr/extractors/csv.py", line 180, in run_csv_extractors
    for prefix, s in pool.imap_unordered(_run_csv_extractor, to_process):
  File "/fh/fast/setty_m/user/dotto/mamba/envs/EHRSHOT_ENV_3/lib/python3.10/multiprocessing/pool.py", line 873, in next
    raise value
KeyError: 'value_as_concept_id'
```

However, in the example files the column seems to be named `observation_concept_id`. So, in this PR I changed the respective `concept_id_value_field` for the `_ConceptTableConverter` and the `_ConceptTableConverter` which seems to fix the issue. Please let me know if I should make any changes to the PR or if I just ran the tutorial in a wrong way.