### PR TITLE
Make `batch_size` an argument in labeler apply function

### DIFF
--- a/src/femr/labelers/core.py
+++ b/src/femr/labelers/core.py
@@ -70,6 +70,7 @@ class Labeler(ABC):
         self,
         dataset: datasets.Dataset,
         num_proc: int = 1,
+        batch_size: int = 10_000,
     ) -> List[meds.Label]:
         """Apply the `label()` function one-by-one to each Patient in a sequence of Patients.
 
@@ -85,7 +86,7 @@ class Labeler(ABC):
             dataset,
             functools.partial(_label_map_func, labeler=self),
             _label_agg_func,
-            batch_size=10_000,
+            batch_size=batch_size,
             num_proc=num_proc,
         )
 


### PR DESCRIPTION
Users should be able to control the batch size. This is especially helpful when debugging and prototyping on small datasets so that you can see how long it takes to run a labeler on e.g., 10 samples at a time rather than having to wait for a whole 10k samples to process.