### PR TITLE
Update transformer.py

### DIFF
--- a/src/femr/models/transformer.py
+++ b/src/femr/models/transformer.py
@@ -376,9 +376,9 @@ def compute_features(
         for key, val in batch.items():
             if isinstance(val, torch.Tensor):
                 batch[key] = batch[key].to(device)
-        for key, val in batch['transformer'].items():
+        for key, val in batch["transformer"].items():
             if isinstance(val, torch.Tensor):
-                batch['transformer'][key] = batch['transformer'][key].to(device)
+                batch["transformer"][key] = batch["transformer"][key].to(device)
 
         with torch.no_grad():
             _, result = model(batch, return_reprs=True)


### PR DESCRIPTION
I get a numpy cuda / cpu conversion error due to the `batches` being moved to `device` before the `collate()` function.

```
Traceback (most recent call last):
  File "/local-scratch-nvme/nigam/ehrshot/lib/python3.10/pdb.py", line 1723, in main
    pdb._runscript(mainpyfile)
  File "/local-scratch-nvme/nigam/ehrshot/lib/python3.10/pdb.py", line 1583, in _runscript
    self.run(statement)
  File "/local-scratch-nvme/nigam/ehrshot/lib/python3.10/bdb.py", line 598, in run
    exec(cmd, globals, locals)
  File "<string>", line 1, in <module>
  File "/share/pi/nigam/mwornow/ehrshot-benchmark/ehrshot/4_generate_clmbr_features.py", line 123, in <module>
    results: Dict[str, Any] = compute_features(dataset, model_name, labels, ontology=None, num_proc=num_threads, tokens_per_batch=tokens_per_batch, device=device)
  File "/share/pi/nigam/mwornow/ehrshot-benchmark/ehrshot/4_generate_clmbr_features.py", line 69, in compute_features
    batch = processor.collate([batch])["batch"]
  File "/local-scratch-nvme/nigam/ehrshot/lib/python3.10/site-packages/femr/models/processor.py", line 401, in collate
    return {"batch": _add_dimension(self.creator.cleanup_batch(batches[0]))}
  File "/local-scratch-nvme/nigam/ehrshot/lib/python3.10/site-packages/femr/models/processor.py", line 322, in cleanup_batch
    batch["transformer"]["patient_lengths"] = np.array(batch["transformer"]["patient_lengths"])
  File "/local-scratch-nvme/nigam/ehrshot/lib/python3.10/site-packages/torch/_tensor.py", line 1062, in __array__
    return self.numpy()
TypeError: can't convert cuda:0 device type tensor to numpy. Use Tensor.cpu() to copy the tensor to host memory first.
```

This fixes that by waiting until after `collate()` to move to device.