### PR TITLE
Fix `visit_occurrence` / `visit` naming discrepancy

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ We recommend users start with our [tutorial folder](https://github.com/som-shahl
 pip install femr
 
 # If you are using deep learning, you also need to install xformers
-# 
-# Note that xformers has some known issues with MacOS. 
+#
+# Note that xformers has some known issues with MacOS.
 # If you are using MacOS you might also need to install llvm. See https://stackoverflow.com/questions/60005176/how-to-deal-with-clang-error-unsupported-option-fopenmp-on-travis
 pip install xformers
 

--- a/src/femr/post_etl_pipelines/stanford.py
+++ b/src/femr/post_etl_pipelines/stanford.py
@@ -20,7 +20,7 @@ from femr.transforms.stanford import (
 
 
 def _is_visit_measurement(e: meds.Measurement) -> bool:
-    return e["metadata"]["table"] == "visit_occurrence"
+    return e["metadata"]["table"] == "visit"
 
 
 def _get_stanford_transformations() -> Callable[[meds.Patient], meds.Patient]:

--- a/src/femr/transforms/stanford.py
+++ b/src/femr/transforms/stanford.py
@@ -41,7 +41,7 @@ def move_visit_start_to_first_event_start(patient: meds.Patient) -> meds.Patient
     # Find the stated start time for each visit
     for event in patient["events"]:
         for measurement in event["measurements"]:
-            if measurement["metadata"]["table"] == "visit_occurrence":
+            if measurement["metadata"]["table"] == "visit":
                 if (
                     measurement["metadata"]["visit_id"] in visit_starts
                     and visit_starts[measurement["metadata"]["visit_id"]] != event["time"]
@@ -72,7 +72,7 @@ def move_visit_start_to_first_event_start(patient: meds.Patient) -> meds.Patient
     for event in patient["events"]:
         new_measurements = []
         for measurement in event["measurements"]:
-            if measurement["metadata"]["table"] == "visit_occurrence":
+            if measurement["metadata"]["table"] == "visit":
                 # Triggers if there is a non-visit event associated with the visit ID that has
                 # start time strictly after the recorded visit start
                 if measurement["metadata"]["visit_id"] in first_event_starts:

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -66,7 +66,7 @@ def test_move_visit_start_ignores_other_visits() -> None:
                     {
                         "code": 4567,
                         "metadata": {
-                            "table": "visit_occurrence",
+                            "table": "visit",
                             "visit_id": 9999,
                         },
                     }
@@ -102,7 +102,7 @@ def test_move_visit_start_ignores_other_visits() -> None:
                     {
                         "code": 4567,
                         "metadata": {
-                            "table": "visit_occurrence",
+                            "table": "visit",
                             "visit_id": 9999,
                         },
                     }
@@ -128,7 +128,7 @@ def test_move_visit_start_minute_after_midnight() -> None:
             {
                 "time": datetime.datetime(1999, 7, 2),
                 "measurements": [
-                    {"code": 3456, "metadata": {"visit_id": 9999, "table": "visit_occurrence"}},
+                    {"code": 3456, "metadata": {"visit_id": 9999, "table": "visit"}},
                     {"code": 1234, "metadata": {"visit_id": 9999}},
                 ],
             },
@@ -152,7 +152,7 @@ def test_move_visit_start_minute_after_midnight() -> None:
             },
             {
                 "time": datetime.datetime(1999, 7, 2, 0, 1),
-                "measurements": [{"code": 3456, "metadata": {"visit_id": 9999, "table": "visit_occurrence"}}],
+                "measurements": [{"code": 3456, "metadata": {"visit_id": 9999, "table": "visit"}}],
             },
             {
                 "time": datetime.datetime(1999, 7, 2, 0, 1),
@@ -179,7 +179,7 @@ def test_move_visit_start_doesnt_move_without_event() -> None:
                 "time": datetime.datetime(1999, 7, 2),
                 "measurements": [
                     {"code": 1234, "metadata": {"visit_id": 9999}},
-                    {"code": 3456, "metadata": {"visit_id": 9999, "table": "visit_occurrence"}},
+                    {"code": 3456, "metadata": {"visit_id": 9999, "table": "visit"}},
                     {"code": 2345, "metadata": {"visit_id": 9999}},
                 ],
             },
@@ -195,7 +195,7 @@ def test_move_visit_start_doesnt_move_without_event() -> None:
                 "time": datetime.datetime(1999, 7, 2),
                 "measurements": [
                     {"code": 1234, "metadata": {"visit_id": 9999}},
-                    {"code": 3456, "metadata": {"visit_id": 9999, "table": "visit_occurrence"}},
+                    {"code": 3456, "metadata": {"visit_id": 9999, "table": "visit"}},
                     {"code": 2345, "metadata": {"visit_id": 9999}},
                 ],
             }


### PR DESCRIPTION
Bug fix -- table is named `visit` in MEDS, not `visit_occurrence`