### PR TITLE
bugfix: fix bug for mkdir command

### DIFF
--- a/tutorials/6_Train MOTOR.ipynb
+++ b/tutorials/6_Train MOTOR.ipynb
@@ -100,7 +100,7 @@
     "index = femr.index.PatientIndex(dataset, num_proc=4)\n",
     "main_split = femr.splits.generate_hash_split(index.get_patient_ids(), 97, frac_test=0.15)\n",
     "\n",
-    "os.mkdir(os.path.join(TARGET_DIR, 'motor_model'))\n",
+    "os.makedirs(os.path.join(TARGET_DIR, 'motor_model'), exist_ok=True)\n",
     "# Note that we want to save this to the target directory since this is important information\n",
     "\n",
     "main_split.save_to_csv(os.path.join(TARGET_DIR, \"motor_model\", \"main_split.csv\"))\n",
@@ -556,7 +556,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.14"
+   "version": "3.11.3"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
In Tutorial 6, the following error message occurs when trying to run the tutorial more than once:

Cell In[10], line 14
     11 index = femr.index.PatientIndex(dataset, num_proc=4)
     12 main_split = femr.splits.generate_hash_split(index.get_patient_ids(), 97, frac_test=0.15)
---> 14 os.mkdir(os.path.join(TARGET_DIR, 'motor_model'))
     15 # Note that we want to save this to the target directory since this is important information
     17 main_split.save_to_csv(os.path.join(TARGET_DIR, "motor_model", "main_split.csv"))

FileExistsError: [Errno 17] File exists: 'trash/tutorial_6/motor_model'

The error occurs because the directory 'trash/tutorial_6/motor_model' already exists when the code tries to create it. To fix this, use os.makedirs() instead of os.mkdir() with a exist_ok=True parameter so a FileExistsError is not raised if the directory already exists. This allows for the tutorial code to be run more than once.
